### PR TITLE
Handle links that open in a new window / frame

### DIFF
--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -1,15 +1,12 @@
-import { File, Trace, alert, confirm, knownFolders, profile, prompt } from '@nativescript/core';
+import { alert, confirm, File, knownFolders, profile, prompt, Trace } from '@nativescript/core';
 import { isEnabledProperty } from '@nativescript/core/ui/core/view';
-import { webViewBridge } from './nativescript-webview-bridge-loader';
 import {
-    NavigationType,
-    NotaTraceCategory,
-    WebViewExtBase,
     allowsInlineMediaPlaybackProperty,
     autoInjectJSBridgeProperty,
-    mediaPlaybackRequiresUserActionProperty,
-    scrollBounceProperty
+    mediaPlaybackRequiresUserActionProperty, NavigationType,
+    NotaTraceCategory, scrollBounceProperty, WebViewExtBase
 } from './index.common';
+import { webViewBridge } from './nativescript-webview-bridge-loader';
 
 export * from './index.common';
 
@@ -818,4 +815,14 @@ export class WKUIDelegateNotaImpl extends NSObject implements WKUIDelegate {
             gotResponse = true;
         });
     }
+
+
+    webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures(webView: WKWebView, configuration: WKWebViewConfiguration, navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures): WKWebView {
+        // Handle links that open in a new window / frame (via target="_blank" or window.open())
+        if (navigationAction && (!navigationAction.targetFrame || (navigationAction.targetFrame && !navigationAction.targetFrame.mainFrame))) {
+            webView.loadRequest(navigationAction.request);
+        }
+
+        return null;
+	}
 }


### PR DESCRIPTION
Currently, ui-webview does not open any links that have `target='_blank'` set or that are opened via `window.open()`. This change is picked from the official Nativescript webview here: https://github.com/NativeScript/NativeScript/pull/9430

I could not test this change with my current project directly as I had some problems creating a new package via `npm run build` (due to some config problems regarding Typescript as a tsconfig file was missing and some other issues). But it worked when I directly patched the npm package (although I manually transformed this code to Javascript beforehand).

@farfromrefug If you think this PR is useful and if you think I should test this again, I can test this change directly. But for that, I would need a package. The easiest solution for me would be, if you could create a package from this PR? But I also can create a package by myself. Then I would need the steps needed to build a package. Sorry, if I overlooked something for building a package (and thank you for maintaining this package!)