### PR TITLE
Update Angular module and component names

### DIFF
--- a/src/webview/angular/index.ts
+++ b/src/webview/angular/index.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { NativeScriptCommonModule, isKnownView, registerElement } from '@nativescript/angular';
 
-const webviewElementName = 'WebViewExt';
+const webviewElementName = 'AWebView';
 
 if (!isKnownView(webviewElementName)) {
-    registerElement(webviewElementName, () => require('@nativescript-community/ui-webview').WebViewExt);
+    registerElement(webviewElementName, () => require('@nativescript-community/ui-webview').AWebView);
 }
 
 @NgModule()
-export class WebViewExtModule {
+export class AWebViewModule {
     imports: [NativeScriptCommonModule];
 }


### PR DESCRIPTION
Angular flavor of this does not currently work. This changes the names to match what is in the documentation. Is this enough to fix Angular version? I don't know.

- Change component name from  'WebViewExt' to 'AWebView'
- Change module name from 'WebViewExtModule' to 'AWebViewModule'