### PR TITLE
iOS - Add debug mode + emit events without data

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The custom `NSURLProtocol` used with UIWebView is shared with all instances of t
 | builtInZoomControls | true / false | Android: Is the built-in zoom mechanisms being used |
 | cacheMode | default / no_cache / cache_first / cache_only | Android: Set caching mode. |
 | databaseStorage | true / false | Android: Enable/Disabled database storage API. Note: It affects all webviews in the process. |
-| debugMode | true / false | Android: Enable chrome debugger for webview on Android. Note: Applies to all webviews in App |
+| debugMode | true / false | Enable chrome debugger for webview on Android and Safari debugger for webview on iOS. Note: Applies to all webviews in App |
 | displayZoomControls | true / false | Android: displays on-screen zoom controls when using the built-in zoom mechanisms |
 | domStorage | true / false | Android: Enable/Disabled DOM Storage API. E.g localStorage |
 | scalesPageToFit | UIWebView: Should webpage scale to fit the view? Defaults to false |

--- a/src/webview/index.common.ts
+++ b/src/webview/index.common.ts
@@ -103,12 +103,6 @@ export const isScrollEnabledProperty = new Property<WebViewExtBase, boolean>({
     valueConverter: booleanConverter
 });
 
-export const normalizeUrlsProperty = new Property<WebViewExtBase, boolean>({
-    name: 'normalizeUrls',
-    defaultValue: true,
-    valueConverter: booleanConverter
-});
-
 export const limitsNavigationsToAppBoundDomainsProperty = new Property<WebViewExtBase, boolean>({
     name: 'limitsNavigationsToAppBoundDomains',
     valueConverter: booleanConverter
@@ -389,7 +383,6 @@ export class UnsupportedSDKError extends Error {
 @CSSType('WebView')
 export abstract class WebViewExtBase extends ContainerView {
     public webConsoleEnabled: boolean;
-    public normalizeUrls: boolean;
 
     public static readonly supportXLocalScheme: boolean;
 
@@ -551,7 +544,6 @@ export abstract class WebViewExtBase extends ContainerView {
      * Callback for the loadFinished-event. Called from the native-webview
      */
     public async _onLoadFinished(url: string, error?: string): Promise<LoadFinishedEventData> {
-        url = this.normalizeURL(url);
         if (Trace.isEnabled()) {
             Trace.write(`WebViewExt._onLoadFinished("${url}", ${error || void 0} ${this.autoInjectJSBridge}) - > Injecting webview-bridge JS code`, WebViewTraceCategory, Trace.messageType.info);
         }
@@ -857,8 +849,6 @@ export abstract class WebViewExtBase extends ContainerView {
         }
 
         if (lcSrc.startsWith(this.interceptScheme) || lcSrc.startsWith('http://') || lcSrc.startsWith('https://') || lcSrc.startsWith('file:///')) {
-            src = this.normalizeURL(src);
-
             if (originSrc !== src) {
                 // Make sure the src-property reflects the actual value.
                 try {
@@ -1113,17 +1103,6 @@ export abstract class WebViewExtBase extends ContainerView {
 
     public removeAutoExecuteJavaScript(name: string) {
         this.autoInjectJavaScriptBlocks = this.autoInjectJavaScriptBlocks.filter((data) => data.name !== name);
-    }
-
-    public normalizeURL(url: string): string {
-        if (!url || !this.normalizeUrls || url.startsWith(this.interceptScheme)) {
-            return url;
-        }
-        try {
-            return require('url').parse(url).format();
-        } catch (error) {
-            return url;
-        }
     }
 
     /**
@@ -1588,7 +1567,6 @@ cacheModeProperty.register(WebViewExtBase);
 databaseStorageProperty.register(WebViewExtBase);
 debugModeProperty.register(WebViewExtBase);
 webConsoleProperty.register(WebViewExtBase);
-normalizeUrlsProperty.register(WebViewExtBase);
 displayZoomControlsProperty.register(WebViewExtBase);
 domStorageProperty.register(WebViewExtBase);
 srcProperty.register(WebViewExtBase);

--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -7,6 +7,7 @@ import {
     WebViewTraceCategory,
     allowsInlineMediaPlaybackProperty,
     autoInjectJSBridgeProperty,
+    debugModeProperty,
     limitsNavigationsToAppBoundDomainsProperty,
     mediaPlaybackRequiresUserActionProperty,
     scrollBarIndicatorVisibleProperty,
@@ -404,6 +405,16 @@ export class AWebView extends WebViewExtBase {
 
     [autoInjectJSBridgeProperty.setNative](enabled: boolean) {
         this.loadWKUserScripts(enabled);
+    }
+
+    [debugModeProperty.getDefault]() {
+        return false;
+    }
+
+    [debugModeProperty.setNative](enabled) {
+        const nativeView = this.nativeViewProtected;
+
+        nativeView.inspectable = !!enabled;
     }
 
     [scrollBounceProperty.getDefault]() {

--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -758,7 +758,13 @@ export class WKScriptMessageHandlerNotaImpl extends NSObject implements WKScript
 
         try {
             const message = JSON.parse(webViewMessage.body as string);
-            owner.onWebViewEvent(message.eventName, JSON.parse(message.data));
+
+            try {
+                owner.onWebViewEvent(message.eventName, JSON.parse(message.data));
+            } catch (err) {
+                owner.writeTrace(`userContentControllerDidReceiveScriptMessage(${userContentController}, ${webViewMessage}) - couldn't parse data: ${message.data}`, Trace.messageType.error);
+                owner.onWebViewEvent(message.eventName, message.data);
+            }
         } catch (err) {
             owner.writeTrace(`userContentControllerDidReceiveScriptMessage(${userContentController}, ${webViewMessage}) - bad message: ${webViewMessage.body}`, Trace.messageType.error);
         }


### PR DESCRIPTION
Hi @farfromrefug!

Here is a PR fixing two bugs. 

About the issue with events emission, I noticed it in my app and decided to handle it the same way it is handled on Android.

I also wanted to fix the Webpack issue reported in #9, but I don't know what is the best way. Personnaly, I would completely get rid of the `normalizeUrl` part and use urls as they are. What do you think?