### PR TITLE
On Android, do not set the client or bridge interface properties on the nativeView additionally to calling the setter methods

### DIFF
--- a/src/webview/index.android.ts
+++ b/src/webview/index.android.ts
@@ -662,20 +662,16 @@ export class AWebView extends WebViewExtBase {
             const client = this.createWebViewClient(this, WebViewExtClient);
 
             nativeView.setWebViewClient(client);
-            nativeView.client = client;
         } else {
             const client = new WebViewExtClient(this);
             nativeView.setWebViewClient(client);
-            nativeView.client = client;
         }
         const chromeClient = new WebChromeViewExtClient(this);
 
         nativeView.setWebChromeClient(chromeClient);
-        nativeView.chromeClient = chromeClient;
 
         const bridgeInterface = new WebViewBridgeInterface(this);
         nativeView.addJavascriptInterface(bridgeInterface, 'androidWebViewBridge');
-        nativeView.bridgeInterface = bridgeInterface;
     }
 
     public disposeNativeView() {


### PR DESCRIPTION
As reported here, this should fix the sporadic "Cannot find runtime for.." crashes on Android:

https://github.com/nativescript-community/ui-webview/issues/22#issuecomment-2940171442

fixes #22 