### PR TITLE
feat(ios): add `supportPopups` property

### DIFF
--- a/packages/webview/README.md
+++ b/packages/webview/README.md
@@ -78,6 +78,7 @@ The custom `NSURLProtocol` used with UIWebView is shared with all instances of t
 | supportZoom | true / false | Android: should the webview support zoom |
 | viewPortSize | false / view-port string / ViewPortProperties | Set the viewport metadata on load finished. **Note:** WkWebView sets initial-scale=1.0 by default. |
 | limitsNavigationsToAppBoundDomains | false | iOS: allows to enable Service Workers **Note:** If set to true, WKAppBoundDomains also should be set in info.plist. |
+| supportPopups | true / false | iOS: should the webview support popup windows (window.open, target="_blank"). Defaults to true |
 | scrollBarIndicatorVisible | false | Allow to hide scrollbars. |
 
 | Function | Description |

--- a/src/webview/index.common.ts
+++ b/src/webview/index.common.ts
@@ -79,6 +79,12 @@ export const allowsInlineMediaPlaybackProperty = new Property<WebViewExtBase, bo
     valueConverter: booleanConverter
 });
 
+export const supportPopupsProperty = new Property<WebViewExtBase, boolean>({
+    name: 'supportPopups',
+    defaultValue: true,
+    valueConverter: booleanConverter
+});
+
 export const srcProperty = new Property<WebViewExtBase, string>({
     name: 'src'
 });
@@ -406,6 +412,8 @@ export abstract class WebViewExtBase extends ContainerView {
     public static isPromiseSupported: boolean;
 
     public scrollBarIndicatorVisible: boolean;
+
+    public supportPopups: boolean;
 
     public get interceptScheme() {
         return 'x-local';
@@ -1536,5 +1544,6 @@ viewPortProperty.register(WebViewExtBase);
 isScrollEnabledProperty.register(WebViewExtBase);
 scalesPageToFitProperty.register(WebViewExtBase);
 mediaPlaybackRequiresUserActionProperty.register(WebViewExtBase);
+supportPopupsProperty.register(WebViewExtBase);
 limitsNavigationsToAppBoundDomainsProperty.register(WebViewExtBase);
 scrollBarIndicatorVisibleProperty.register(WebViewExtBase);


### PR DESCRIPTION
- Add supportPopups boolean property (default: true)
- Enable/disable popup window creation in iOS WebView
- Fallback to main WebView when popups disabled

This allows Google OAuth and similar authentication flows to work properly in the WebView
