### PR TITLE
fix(ios): create separate userContentController for popup webviews

### DIFF
--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -895,7 +895,9 @@ export class WKUIDelegateNotaImpl extends NSObject implements WKUIDelegate {
             if (supportPopups) {
                 try {
                     const popupConfig = configuration;
-                    popupConfig.userContentController.removeAllUserScripts();
+                    // iOS shares WKUserContentController between parent and popup webviews by default.
+                    // Create a fresh controller to prevent user scripts from being injected into popups.
+                    popupConfig.userContentController = WKUserContentController.alloc().init();
 
                     let popupWebView = WKWebView.alloc().initWithFrameConfiguration(CGRectZero, popupConfig);
 


### PR DESCRIPTION
iOS passes a shared `WKUserContentController` reference to popup webviews. The existing implementation calls `removeAllUserScripts()` to clean popups, but since the controller is shared, this also removes all scripts from the parent webview, breaking JavaScript bridge.

This fix creates a new isolated `WKUserContentController` instance for popups instead of modifying the shared one.