### PR TITLE
fix(android): prevent crash when shouldInterceptRequest is called on background thread

### DIFF
--- a/src/webview/index.android.ts
+++ b/src/webview/index.android.ts
@@ -147,72 +147,76 @@ function initializeWebViewClient(): void {
         }
 
         public shouldInterceptRequest(view: android.webkit.WebView, request: string | android.webkit.WebResourceRequest) {
-            const owner = this.owner.get();
-            if (!owner) {
-                if (Trace.isEnabled()) {
-                    Trace.write('WebViewExtClientImpl.shouldInterceptRequest() - no owner', WebViewTraceCategory, Trace.messageType.warn);
+            try {
+                const owner = this.owner.get();
+                if (!owner) {
+                    if (Trace.isEnabled()) {
+                        Trace.write('WebViewExtClientImpl.shouldInterceptRequest() - no owner', WebViewTraceCategory, Trace.messageType.warn);
+                    }
+                    return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
                 }
-                return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
-            }
 
-            let url: string | void;
-            if (typeof request === 'string') {
-                url = request;
-            } else if (typeof request === 'object') {
-                url = request.getUrl().toString();
-            }
-
-            if (typeof url !== 'string') {
-                if (Trace.isEnabled()) {
-                    Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - is not a string`, WebViewTraceCategory, Trace.messageType.info);
+                let url: string | void;
+                if (typeof request === 'string') {
+                    url = request;
+                } else if (typeof request === 'object') {
+                    url = request.getUrl().toString();
                 }
-                return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
-            }
 
-            if (!url.startsWith(owner.interceptScheme)) {
-                return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
-            }
-
-            const filepath = owner.getRegisteredLocalResource(url);
-            if (!filepath) {
-                if (Trace.isEnabled()) {
-                    Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - no matching file`, WebViewTraceCategory, Trace.messageType.info);
+                if (typeof url !== 'string') {
+                    if (Trace.isEnabled()) {
+                        Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - is not a string`, WebViewTraceCategory, Trace.messageType.info);
+                    }
+                    return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
                 }
-                return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
-            }
 
-            if (!File.exists(filepath)) {
-                if (Trace.isEnabled()) {
-                    Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - file: "${filepath}" doesn't exists`, WebViewTraceCategory, Trace.messageType.info);
+                if (!url.startsWith(owner.interceptScheme)) {
+                    return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
                 }
-                return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
-            }
 
-            const tnsFile = File.fromPath(filepath);
+                const filepath = owner.getRegisteredLocalResource(url);
+                if (!filepath) {
+                    if (Trace.isEnabled()) {
+                        Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - no matching file`, WebViewTraceCategory, Trace.messageType.info);
+                    }
+                    return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
+                }
 
-            const javaFile = new java.io.File(tnsFile.path);
-            const stream = new java.io.FileInputStream(javaFile);
-            const ext = tnsFile.extension.substring(1).toLowerCase();
-            const mimeType = extToMimeType.get(ext) || 'application/octet-stream';
-            const encoding = extToBinaryEncoding.has(ext) || mimeType === 'application/octet-stream' ? 'binary' : 'UTF-8';
+                if (!File.exists(filepath)) {
+                    if (Trace.isEnabled()) {
+                        Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - file: "${filepath}" doesn't exists`, WebViewTraceCategory, Trace.messageType.info);
+                    }
+                    return super.shouldInterceptRequest(view, request as android.webkit.WebResourceRequest);
+                }
 
-            if (Trace.isEnabled()) {
-                Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - file: "${filepath}" mimeType:${mimeType} encoding:${encoding}`, WebViewTraceCategory, Trace.messageType.info);
-            }
-            const response = new android.webkit.WebResourceResponse(mimeType, encoding, stream);
-            if (sdkVersion() < 21 || !response.getResponseHeaders) {
+                const tnsFile = File.fromPath(filepath);
+
+                const javaFile = new java.io.File(tnsFile.path);
+                const stream = new java.io.FileInputStream(javaFile);
+                const ext = tnsFile.extension.substring(1).toLowerCase();
+                const mimeType = extToMimeType.get(ext) || 'application/octet-stream';
+                const encoding = extToBinaryEncoding.has(ext) || mimeType === 'application/octet-stream' ? 'binary' : 'UTF-8';
+
+                if (Trace.isEnabled()) {
+                    Trace.write(`WebViewClientClass.shouldInterceptRequest("${url}") - file: "${filepath}" mimeType:${mimeType} encoding:${encoding}`, WebViewTraceCategory, Trace.messageType.info);
+                }
+                const response = new android.webkit.WebResourceResponse(mimeType, encoding, stream);
+                if (sdkVersion() < 21 || !response.getResponseHeaders) {
+                    return response;
+                }
+
+                let responseHeaders = response.getResponseHeaders();
+                if (!responseHeaders) {
+                    responseHeaders = new java.util.HashMap<string, string>();
+                }
+
+                responseHeaders.put('Access-Control-Allow-Origin', '*');
+                response.setResponseHeaders(responseHeaders);
+
                 return response;
+            } catch (e) {
+                return null;
             }
-
-            let responseHeaders = response.getResponseHeaders();
-            if (!responseHeaders) {
-                responseHeaders = new java.util.HashMap<string, string>();
-            }
-
-            responseHeaders.put('Access-Control-Allow-Origin', '*');
-            response.setResponseHeaders(responseHeaders);
-
-            return response;
         }
 
         public onPageStarted(view: android.webkit.WebView, url: string, favicon: android.graphics.Bitmap) {


### PR DESCRIPTION
Chromium may invoke `shouldInterceptRequest` on its IO thread, where the NativeScript V8 runtime is unavailable. This causes a fatal "Cannot find runtime for instance" error, most commonly observed after returning the app from background.

Wrapping the method body in `try/catch` and returning `null` on failure falls back to default WebView request handling with no visible side effects.

fix https://github.com/nativescript-community/ui-webview/issues/22