### PR TITLE
fix(android): unblock WebView JS thread during bridge event dispatch

### DIFF
--- a/src/webview/index.android.ts
+++ b/src/webview/index.android.ts
@@ -598,15 +598,19 @@ function initializeWebViewClient(): void {
                 return;
             }
 
-            try {
-                return owner.onWebViewEvent(eventName, JSON.parse(data));
-            } catch (err) {
-                if (Trace.isEnabled()) {
-                    Trace.write(`WebViewExtClientImpl.emitEventToNativeScript("${eventName}") - couldn't parse data: ${data} err: ${err}`, WebViewTraceCategory, Trace.messageType.info);
+            // Dispatch asynchronously so the JavaBridge thread returns immediately,
+            // unblocking the WebView's JS thread without waiting for NativeScript to
+            // finish processing the event
+            setTimeout(() => {
+                try {
+                    owner.onWebViewEvent(eventName, JSON.parse(data));
+                } catch (err) {
+                    if (Trace.isEnabled()) {
+                        Trace.write(`WebViewExtClientImpl.emitEventToNativeScript("${eventName}") - couldn't parse data: ${data} err: ${err}`, WebViewTraceCategory, Trace.messageType.info);
+                    }
+                    owner.onWebViewEvent(eventName, data);
                 }
-            }
-
-            owner.onWebViewEvent(eventName, data);
+            }, 0);
         }
     }
 


### PR DESCRIPTION
## Problem

`emitEventToNativeScript` runs on the JavaBridge thread. NativeScript dispatches the call to its V8 thread and blocks until the handler completes - store updates, native view property changes, etc.

Under frequent bridge calls in complex scenes with many active scripts, this starves the WebView render pipeline by 10–30 ms per call, accumulating to hundreds of milliseconds of blocked time per second.

## Fix

Wrap `onWebViewEvent` in `setTimeout(0)` so the JavaBridge thread returns immediately and NativeScript processes the event on its next tick.

## Trade-off

Events become asynchronous relative to the WebView caller. Any code that relies on NativeScript state being updated synchronously after a bridge call would be affected. However, this path is architecturally one-way: `emitEventToNativeScript` is declared `void` in the `@JavascriptInterface` contract, so no return value can be passed back to WebView JS regardless. The NativeScript -> WebView channel operates independently via `executeJavaScript`.