### PR TITLE
fix(ios): skip subframe intercepts, improve auth popup support

### DIFF
--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -675,6 +675,11 @@ export class WKNavigationDelegateNotaImpl extends NSObject implements WKNavigati
             }
         }
 
+        const isMainFrame = !navigationAction.targetFrame || navigationAction.targetFrame.mainFrame;
+        if (!isMainFrame) {
+            decisionHandler(WKNavigationActionPolicy.Allow);
+            return;
+        }
         const shouldOverrideUrlLoading = owner._onShouldOverrideUrlLoading(url, httpMethod, navType);
         if (shouldOverrideUrlLoading === true) {
             if (Trace.isEnabled()) {
@@ -683,8 +688,8 @@ export class WKNavigationDelegateNotaImpl extends NSObject implements WKNavigati
                     WebViewTraceCategory,
                     Trace.messageType.info
                 );
-                decisionHandler(WKNavigationActionPolicy.Cancel);
             }
+            decisionHandler(WKNavigationActionPolicy.Cancel);
             return;
         }
         decisionHandler(WKNavigationActionPolicy.Allow);
@@ -905,7 +910,7 @@ export class WKUIDelegateNotaImpl extends NSObject implements WKUIDelegate {
                         popupWebView.customUserAgent = webView.customUserAgent;
                     }
 
-                    let currentVC = UIApplication.sharedApplication.keyWindow.rootViewController;
+                    let currentVC = webView.window ? webView.window.rootViewController : null;
                     while (currentVC && currentVC.presentedViewController) {
                         currentVC = currentVC.presentedViewController;
                     }


### PR DESCRIPTION
- Skip `shouldOverrideUrlLoading` for subframes (iframes) to match Android behaviour (https://github.com/nativescript-community/ui-webview/pull/29) and avoid blocking cross-origin auth flows (OAuth, gapi)
- Replace deprecated `keyWindow` with `webView.window` for popup presentation
- Move `decisionHandler(Cancel)` outside `Trace.isEnabled()` block - navigation cancel was silently no-op in production builds without tracing