### PR TITLE
fix(ios): report navigations happening in popups and server redirects

### DIFF
--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -34,7 +34,9 @@ export class AWebView extends WebViewExtBase {
     public static supportXLocalScheme = typeof CustomUrlSchemeHandler !== 'undefined';
 
     protected wkWebViewConfiguration: WKWebViewConfiguration;
-    protected wkNavigationDelegate: WKNavigationDelegateNotaImpl;
+    // public so popup webviews created by the UI delegate can reuse it, see
+    // `webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures`
+    public wkNavigationDelegate: WKNavigationDelegateNotaImpl;
     protected wkUIDelegate: WKUIDelegateNotaImpl;
     protected wkCustomUrlSchemeHandler: CustomUrlSchemeHandler | void;
     protected wkUserContentController: WKUserContentController;
@@ -968,6 +970,11 @@ export class WKUIDelegateNotaImpl extends NSObject implements WKUIDelegate {
                             .init();
 
                         popupWebView.UIDelegate = simpleUIDelegate;
+                        // Without a navigation delegate the popup is a blind spot: `shouldOverrideUrlLoading`,
+                        // `loadStarted` and `loadFinished` would never fire for anything loaded in it.
+                        if (owner) {
+                            popupWebView.navigationDelegate = owner.wkNavigationDelegate;
+                        }
 
                         currentVC.presentViewControllerAnimatedCompletion(navController, true, null);
                         return popupWebView;

--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -683,8 +683,9 @@ export class WKNavigationDelegateNotaImpl extends NSObject implements WKNavigati
                     WebViewTraceCategory,
                     Trace.messageType.info
                 );
-                decisionHandler(WKNavigationActionPolicy.Cancel);
             }
+            decisionHandler(WKNavigationActionPolicy.Cancel);
+
             return;
         }
         decisionHandler(WKNavigationActionPolicy.Allow);

--- a/src/webview/index.ios.ts
+++ b/src/webview/index.ios.ts
@@ -713,6 +713,25 @@ export class WKNavigationDelegateNotaImpl extends NSObject implements WKNavigati
         }
     }
 
+    /**
+     * A server-side redirect does not go through `decidePolicyForNavigationAction`, so without this the
+     * url the navigation was redirected to would never be reported. Android reports it through
+     * `onPageStarted`, this keeps `loadStarted` consistent across platforms.
+     */
+    public webViewDidReceiveServerRedirectForProvisionalNavigation(webView: WKWebView, navigation: WKNavigation): void {
+        const owner = this.owner.get();
+        const url = webView.URL?.absoluteString;
+        if (!owner || !url) {
+            return;
+        }
+
+        if (Trace.isEnabled()) {
+            Trace.write(`WKNavigationDelegateClass.webViewDidReceiveServerRedirectForProvisionalNavigation("${url}")`, WebViewTraceCategory, Trace.messageType.info);
+        }
+
+        owner._onLoadStarted(url, 'other');
+    }
+
     public webViewDidFinishNavigation(webView: WKWebView, navigation: WKNavigation): void {
         const owner = this.owner.get();
         if (!owner) {


### PR DESCRIPTION
## Summary

Three iOS navigation-delegate gaps, all found from the same symptom: a `target="_blank"` link that redirects server-side was loading fine but never reaching the app's `shouldOverrideUrlLoading`.

- **`decisionHandler` was never called when cancelling, unless tracing was on.** The call sat inside `if (Trace.isEnabled())`, so for every app running without `Trace` — i.e. production — returning `true` from `shouldOverrideUrlLoading` did not cancel the navigation, and iOS logged that the completion handler was never invoked.
- **Popup webviews had no navigation delegate.** `webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures` builds a fresh `WKWebView` for `target="_blank"` / `window.open()` and assigned only a `UIDelegate`, making the popup a blind spot — `shouldOverrideUrlLoading`, `loadStarted` and `loadFinished` never fired for anything loaded in it. It now reuses the owner's navigation delegate (the field had to become `public`).
- **Server-side redirects emitted no event.** WKWebView skips `decidePolicyForNavigationAction` for redirects and calls `didReceiveServerRedirectForProvisionalNavigation`, which was not implemented, so the redirected url was never reported. Android already surfaces these through `onPageStarted`; iOS now emits `loadStarted` for them too.

## Behaviour changes to be aware of

- Cancelling from `shouldOverrideUrlLoading` now actually cancels on iOS in release builds. Apps that returned `true` and silently got a navigation anyway will see the navigation stop.
- Navigations inside popups now emit `loadStarted` / `loadFinished` / `shouldOverrideUrlLoading` on the owning `AWebView`.

## Testing

`tsc --noEmit` and `eslint` are clean for the touched file. **Not yet run on a device** — needs a manual iOS check: a page with a `target="_blank"` link whose target 302s to another host, verifying the final url reaches `shouldOverrideUrlLoading` (both with `supportPopups` on and off) and that cancelling it works with tracing disabled.