### PR TITLE
fix(webview-rtc): pin WKWebViewRTC to a WebRTC-lib build

### DIFF
--- a/packages/webview-rtc/platforms/ios/Podfile
+++ b/packages/webview-rtc/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'WKWebViewRTC', :git => 'https://github.com/farfromrefug/WKWebViewRTC.git', :branch => 'dev'
+pod 'WKWebViewRTC', :git => 'https://github.com/farfromrefug/WKWebViewRTC.git', :commit => 'd8170ad6be379a9db8c8bd4426bf1edcda27e9f2'


### PR DESCRIPTION
## Summary

iOS simulator builds of `@nativescript-community/ui-webview-rtc` are broken on Apple Silicon.
`WKWebViewRTC` depends on `GoogleWebRTC`, unmaintained since 2019, whose `WebRTC.framework` has
`x86_64 i386 armv7 arm64` slices — the `arm64` one is **device**, so linking a simulator build fails:

```
ld: building for 'iOS-simulator', but linking in dylib ... built for 'iOS'
```

The usual `EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64` workaround no longer helps: iOS 26 simulator
runtimes refuse to install an x86_64 app (`Failed to find matching arch`).

## Changes

- Pin the `WKWebViewRTC` pod to farfromrefug/WKWebViewRTC@d8170ad instead of tracking `dev`.
  That commit:
  - swaps `GoogleWebRTC` for `WebRTC-lib` (~> 151.0) — the community distribution of the official
    WebRTC binaries, whose xcframework has an `ios-x86_64_arm64-simulator` slice
  - ports `iMediaStreamRenderer` from `RTCEAGLVideoView` to `RTCMTLVideoView`; the official binaries
    no longer export the EAGL view (OpenGL ES dropped for Metal)
  - drops `ONLY_ACTIVE_ARCH` from the podspec xcconfig — combined with an `EXCLUDED_ARCHS` workaround
    on the consumer side it resolves to an empty arch list and the pod silently builds nothing

## Verification

- Built a consuming app (Alpi Maps) for the simulator, Xcode 26.5 on Apple Silicon: builds clean,
  app binary is `x86_64 arm64`, installs and launches on an iOS 26.5 simulator. Both failures above
  are gone.
- No lint/test CI in this repo (only `release.yml`), so nothing else validates this.
- Reviewer scenarios (not exercised — needs a WebRTC peer): `getUserMedia` in a WebView, and video
  rendering through `RTCMTLVideoView` on both device and simulator.

## Notes

- Pinned to a commit rather than `:branch => 'dev'` so plugin builds are reproducible. Happy to point
  at a branch/tag instead if you prefer.
- Device builds were not rebuilt — unchanged code path, but `RTCMTLVideoView` on device deserves a look.